### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/bump-tag.yml
+++ b/.github/workflows/bump-tag.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       

--- a/.github/workflows/mark-latest-tag.yml
+++ b/.github/workflows/mark-latest-tag.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,10 +15,10 @@ jobs:
         os: ["ubuntu-22.04"]
         python_version: ["3.11"]
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
         - name: Setup python
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
           with:
             python-version: ${{ matrix.python_version }}
             architecture: x64

--- a/.github/workflows/sample-workflow-linux.yaml
+++ b/.github/workflows/sample-workflow-linux.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: template validation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - uses: microsoft/template-validation-action@Latest
         id: validation

--- a/.github/workflows/sample-workflow-win.yaml
+++ b/.github/workflows/sample-workflow-win.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     name: template validation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - uses: microsoft/template-validation-action@Latest
         id: validation

--- a/.github/workflows/test-workflow-latest.yml
+++ b/.github/workflows/test-workflow-latest.yml
@@ -19,7 +19,7 @@ jobs:
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Clone repo
         working-directory: ${{ runner.temp }}

--- a/.github/workflows/test-workflow-main.yml
+++ b/.github/workflows/test-workflow-main.yml
@@ -19,7 +19,7 @@ jobs:
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Clone repo
         working-directory: ${{ runner.temp }}

--- a/.github/workflows/validate-ps-rule.yml
+++ b/.github/workflows/validate-ps-rule.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Clone repo
         working-directory: ${{ runner.temp }}

--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
 
     # Analyze templates for MI compliance with PSRule for Azure
     - name: Analyze templates for MI compliance
-      uses: microsoft/ps-rule@v2.9.0
+      uses: microsoft/ps-rule@46451b8f5258c41beb5ae69ed7190ccbba84112c # v2.9.0
       if: ${{ inputs.securityAction == 'PSRule' && env.relative_working_directory != '.' }}
       with:
         path: ${{ env.relative_working_directory }}
@@ -139,7 +139,7 @@ runs:
 
     # Analyze templates for MI compliance with PSRule for Azure
     - name: Analyze templates for MI compliance
-      uses: microsoft/ps-rule@v2.9.0
+      uses: microsoft/ps-rule@46451b8f5258c41beb5ae69ed7190ccbba84112c # v2.9.0
       if: ${{ inputs.securityAction == 'PSRule' && env.relative_working_directory == '.' }}
       with:
         modules: 'PSRule.Rules.Azure'
@@ -308,7 +308,7 @@ runs:
         AZURE_ENV_NAME: ${{ env.AZURE_ENV_NAME }}
 
     - name: Azure login
-      uses: azure/login@v2
+      uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
       if : ${{ inputs.validateAzd == 'true' && env.targetScope == 'resourceGroup' }}
       with:
         client-id: ${{ env.AZURE_CLIENT_ID }}
@@ -334,7 +334,7 @@ runs:
         env > ${{ steps.reform_path.outputs.workingDirectory }}/tva_${{ github.run_id }}/env_variables.txt
       shell: bash
 
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
       id: script
       if: ${{ inputs.useDevContainer == 'true' && inputs.validateAzd == 'true' }}
       with:
@@ -350,7 +350,7 @@ runs:
     # A workaround to those template that using Docker 
     - name: Start Docker
       if: ${{ inputs.useDevContainer == 'true' && inputs.validateAzd == 'true' }}
-      uses: devcontainers/ci@v0.3
+      uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
       with:
         runCmd: |
           if find . -type f -iname 'dockerfile' | grep -q .; then
@@ -362,7 +362,7 @@ runs:
     - name: Login azd in devcontainer
       id: azd-login
       if: ${{ inputs.useDevContainer == 'true' && inputs.validateAzd == 'true' }}
-      uses: devcontainers/ci@v0.3
+      uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
       with:
         runCmd: |
           azd auth login --client-id "${{ env.AZURE_CLIENT_ID }}" --federated-credential-provider "github" --tenant-id "${{ env.AZURE_TENANT_ID }}"
@@ -377,7 +377,7 @@ runs:
     - name: Setup Python in devcontainer
       id: setup-python
       if: ${{ inputs.useDevContainer == 'true' }}
-      uses: devcontainers/ci@v0.3
+      uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
       with:
         runCmd: |
           if ! command -v python &> /dev/null; then
@@ -394,7 +394,7 @@ runs:
     - name: Setup Node in devcontainer
       id: setup-node
       if: ${{ inputs.useDevContainer == 'true' && inputs.validateTests == 'Playwright' }}
-      uses: devcontainers/ci@v0.3
+      uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
       with:
         runCmd: |
           if ! command -v node &> /dev/null; then
@@ -469,7 +469,7 @@ runs:
     - name: Run validation
       id: validation
       if: ${{ inputs.useDevContainer == 'true' }}
-      uses: devcontainers/ci@v0.3
+      uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
       with:
         runCmd: |
           source .venv/bin/activate
@@ -493,7 +493,7 @@ runs:
     - name: Send output to main workflow
       id: send_output
       if: ${{ inputs.useDevContainer == 'true' }}
-      uses: devcontainers/ci@v0.3
+      uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
       with:
         runCmd: |
           cat tva_${{ github.run_id }}/output.log
@@ -501,9 +501,9 @@ runs:
 
     - name: Install AZD
       if: ${{ inputs.useDevContainer == 'false' }}
-      uses: Azure/setup-azd@v2
+      uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553 # v2.4.0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       if: ${{ inputs.useDevContainer == 'false' && inputs.validateTests == 'Playwright' }}
       with:
         node-version: lts/*


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
