### PR TITLE
Pin CI-sensitive dependencies to restore stable builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 azure-identity
-azure.mgmt.resource
+azure.mgmt.resource==25.0.0
 azure.mgmt.cognitiveservices
 pyyaml
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ azure.mgmt.resource
 azure.mgmt.cognitiveservices
 pyyaml
 pytest
-ruff
+ruff==0.15.21
 sarif-tools


### PR DESCRIPTION
Summary: Pin CI-sensitive dependencies to their last compatible releases so unrelated PRs are not broken by upstream package releases. Ruff 0.16.4 introduces 68 lint failures on unchanged main source, while Ruff 0.15.21 passes existing lint and formatting checks. azure.mgmt.resource 26.0.0 moved ResourceManagementClient and breaks the repository's existing import; 25.0.0 preserves the current API. This restores a stable baseline for #96. GitHub Actions runs the complete lint, format, and pytest workflow.